### PR TITLE
correctly set repo for both 4.x and 5.x

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,7 +1,8 @@
 ---
 - name: Configure Debian repo version.
   set_fact:
-    debian_repo_version: "{{ nodejs_version if '4' not in nodejs_version else '4.x' }}"
+    debian_repo_version: '{{ nodejs_version | regex_replace("^([4,5])\.\d$", "\\1.x") }}'
+
 
 - name: Add Nodesource apt key.
   apt_key:


### PR DESCRIPTION
thanks @geerlingguy for your great playbooks!
This PR replaces condition for `debian_repo_version` with `regex_replace` to support both 4.x and 5.x
